### PR TITLE
Add tuxedo-touchpad-toggle executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET gio-2.0 udev)
 add_executable(tuxedo-touchpad-switch tuxedo-touchpad-switch.cpp setup-gnome.cpp setup-kde.cpp touchpad-control.cpp)
 target_link_libraries(tuxedo-touchpad-switch udev PkgConfig::deps)
 
+add_executable(tuxedo-touchpad-toggle tuxedo-touchpad-toggle.cpp touchpad-control.cpp)
+target_link_libraries(tuxedo-touchpad-toggle udev PkgConfig::deps)
+
 install(TARGETS tuxedo-touchpad-switch DESTINATION bin/)
+install(TARGETS tuxedo-touchpad-toggle DESTINATION bin/)
 install(FILES res/99-tuxedo-touchpad-switch.rules DESTINATION lib/udev/rules.d/)
 install(FILES res/tuxedo-touchpad-switch-lockfile DESTINATION /etc/ PERMISSIONS OWNER_READ GROUP_READ WORLD_READ) # absolute path on purpose: implemented as such in tuxedo-touchpad-switch.cpp
 install(FILES res/tuxedo-touchpad-switch.desktop DESTINATION /usr/share/gdm/greeter/autostart/) # absolute path on purpose: gdm has no config dir in /usr/local/

--- a/touchpad-control.cpp
+++ b/touchpad-control.cpp
@@ -144,3 +144,48 @@ int set_touchpad_state(int enabled) {
     
     return result;
 }
+
+int toggle_touchpad_state() {
+    std::vector<std::string> devnodes;
+    int touchpad_count = get_touchpad_hidraw_devices(&devnodes);
+    if (touchpad_count < 0) {
+        cerr << "get_touchpad_hidraw_devices failed." << endl;
+        return EXIT_FAILURE;
+    }
+    if (touchpad_count == 0) {
+        cout << "No compatible touchpads found." << endl;
+        return EXIT_FAILURE;
+    }
+
+    int result = EXIT_SUCCESS;
+
+    for (auto it = devnodes.begin(); it != devnodes.end(); ++it) {
+        int hidraw = open((*it).c_str(), O_WRONLY|O_NONBLOCK);
+        if (hidraw < 0) {
+            cerr << "open(\"" << *it << "\", O_WRONLY|O_NONBLOCK) failed." << endl;
+            result = EXIT_FAILURE;
+        }
+        else {
+            // get the device's state first (feature report nr.7 - 0x07)
+            char buffer[2] = {0x07, 0x00};
+            ioctl(hidraw, HIDIOCGFEATURE(2), buffer);
+
+            // toggle the state
+            if (buffer[1] == 0x00) {
+                buffer[1] = 0x03; // enable touchpad
+            } else {
+                buffer[1] = 0x00; // disable touchpad
+            }
+
+            int result = ioctl(hidraw, HIDIOCSFEATURE(2), buffer);
+            if (result < 0) {
+                cerr << "ioctl on " << *it << " failed." << endl;
+                result = EXIT_FAILURE;
+            }
+
+            close(hidraw);
+        }
+    }
+
+    return result;
+}

--- a/touchpad-control.h
+++ b/touchpad-control.h
@@ -20,3 +20,5 @@
 // "int enable" set to 0 disables the touchpad, any other value enables it
 // returns EXIT_SUCCESS or EXIT_FAILURE accordingly, on fail the activate/deactivate state of found touchpads is undefined
 int set_touchpad_state(int enabled);
+
+int toggle_touchpad_state();

--- a/tuxedo-touchpad-toggle.cpp
+++ b/tuxedo-touchpad-toggle.cpp
@@ -1,0 +1,5 @@
+#include "touchpad-control.h"
+
+int main() {
+    return toggle_touchpad_state();
+}


### PR DESCRIPTION
This PR provides a solution for feature request #2 

When executed, tuxedo-touchpad-toggle toggles the enabled/disabled state of the touchpad. This executable makes it easy to bind the toggle to any key combination so one can toggle the touchpad in any desktop environment.

The implementation is copied from the following comment: https://github.com/tuxedocomputers/tuxedo-touchpad-switch/issues/2#issuecomment-806536830 (FYI, @Mi-La might own the copyright for it?)