### PR TITLE
Added support for X-Cinnamon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ project(tuxedo-touchpad-switch)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(deps REQUIRED IMPORTED_TARGET gio-2.0 libudev)
 
-add_executable(tuxedo-touchpad-switch tuxedo-touchpad-switch.cpp setup-gnome.cpp setup-kde.cpp touchpad-control.cpp)
+add_executable(tuxedo-touchpad-switch tuxedo-touchpad-switch.cpp setup-gnome.cpp setup-cinnamon.cpp setup-kde.cpp touchpad-control.cpp)
 target_link_libraries(tuxedo-touchpad-switch udev PkgConfig::deps)
 
 install(TARGETS tuxedo-touchpad-switch DESTINATION bin/)

--- a/setup-cinnamon.cpp
+++ b/setup-cinnamon.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2020 TUXEDO Computers GmbH <tux@tuxedocomputers.com>
+//
+// This file is part of TUXEDO Touchpad Switch.
+//
+// This file is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// TUXEDO Touchpad Switch is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with TUXEDO Touchpad Switch.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "setup-cinnamon.h"
+
+#include <iostream>
+
+#include <sys/file.h>
+
+#include <gio/gio.h>
+
+#include "touchpad-control.h"
+
+using std::cerr;
+using std::endl;
+
+static int lockfile;
+static GSettings *touchpad_settings = NULL;
+static GDBusProxy *session_manager_properties = NULL;
+static GDBusProxy *display_config_properties = NULL;
+
+static void send_events_handler(GSettings *settings, const char* key, __attribute__((unused)) gpointer user_data) {
+    const gchar *send_events_string = g_settings_get_string(settings, key);
+    if (!send_events_string) {
+        cerr << "send_events_handler(...): g_settings_get_string(...) failed." << endl;
+        return;
+    }
+    
+    int enabled = 0;
+    if (send_events_string[0] == 'e') {
+        enabled = 1;
+    }
+    
+    if (set_touchpad_state(enabled)) {
+        cerr << "send_events_handler(...): set_touchpad_state(...) failed." << endl;
+    }
+}
+
+static void  session_manager_properties_changed_handler(__attribute__((unused)) GDBusProxy *proxy, GVariant *changed_properties, __attribute__((unused)) GStrv invalidated_properties, gpointer user_data) {
+    if (g_variant_is_of_type(changed_properties, G_VARIANT_TYPE_VARDICT)) {
+        GVariantDict changed_properties_dict;
+        gboolean sessionIsActive;
+
+        g_variant_dict_init (&changed_properties_dict, changed_properties);
+        if (g_variant_dict_lookup (&changed_properties_dict, "SessionIsActive", "b", &sessionIsActive)) {
+            if (sessionIsActive) {
+                if (flock(lockfile, LOCK_EX)) {
+                    cerr << "properties_changed_handler(...): flock(...) failed." << endl;
+                }
+                send_events_handler((GSettings *)user_data, "send-events", NULL);
+            }
+            else {
+                if (set_touchpad_state(1)) {
+                    cerr << "properties_changed_handler(...): set_touchpad_state(...) failed." << endl;
+                }
+                if (flock(lockfile, LOCK_UN)) {
+                    cerr << "properties_changed_handler(...): flock(...) failed." << endl;
+                }
+            }
+        }
+    }
+}
+
+static void  display_config_properties_changed_handler(__attribute__((unused)) GDBusProxy *proxy, GVariant *changed_properties, __attribute__((unused)) GStrv invalidated_properties, gpointer user_data) {
+    if (g_variant_is_of_type(changed_properties, G_VARIANT_TYPE_VARDICT)) {
+        GVariantDict changed_properties_dict;
+        gint32 powerSaveMode;
+
+        g_variant_dict_init (&changed_properties_dict, changed_properties);
+        if (g_variant_dict_lookup (&changed_properties_dict, "PowerSaveMode", "i", &powerSaveMode)) {
+            if (powerSaveMode == 0) {
+                send_events_handler((GSettings *)user_data, "send-events", NULL);
+            }
+        }
+    }
+}
+
+int setup_cinnamon(int lockfile_arg) {
+    lockfile = lockfile_arg;
+    
+    // get a new glib settings context to read the touchpad configuration of the current user
+    touchpad_settings = g_settings_new("org.cinnamon.desktop.peripherals.touchpad");
+    if (!touchpad_settings) {
+        cerr << "setup_cinnamon(...): g_settings_new(...) failed." << endl;
+        return EXIT_FAILURE;
+    }
+    
+    // sync on config change
+    if (g_signal_connect(touchpad_settings, "changed::send-events", G_CALLBACK(send_events_handler), NULL) < 1) {
+        cerr << "setup_cinnamon(...): g_signal_connect(...) failed." << endl;
+        return EXIT_FAILURE;
+    }
+    
+    // sync on xsession change
+    session_manager_properties = g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+                                                                           G_DBUS_PROXY_FLAGS_NONE, NULL,
+                                                                           "org.cinnamon.SessionManager",
+                                                                           "/org/cinnamon/SessionManager",
+                                                                           "org.cinnamon.SessionManager",
+                                                                           NULL, NULL);
+    if (session_manager_properties == NULL) {
+        cerr << "setup_cinnamon(...): g_dbus_proxy_new_for_bus_sync(...) failed." << endl;
+        return EXIT_FAILURE;
+    }
+    if (g_signal_connect(session_manager_properties, "g-properties-changed", G_CALLBACK(session_manager_properties_changed_handler), touchpad_settings) < 1) {
+        cerr << "setup_cinnamon(...): g_signal_connect(...) failed." << endl;
+        return EXIT_FAILURE;
+    }
+    
+    // sync on wakeup
+    display_config_properties = g_dbus_proxy_new_for_bus_sync(G_BUS_TYPE_SESSION,
+                                                                          G_DBUS_PROXY_FLAGS_NONE, NULL,
+                                                                          "org.cinnamon.Muffin.DisplayConfig",
+                                                                          "/org/cinnamon/Muffin/DisplayConfig",
+                                                                          "org.cinnamon.Muffin.DisplayConfig",
+                                                                          NULL, NULL);
+    if (display_config_properties == NULL) {
+        cerr << "setup_cinnamon(...): g_dbus_proxy_new_for_bus_sync(...) failed." << endl;
+        return EXIT_FAILURE;
+    }
+    if (g_signal_connect(display_config_properties, "g-properties-changed", G_CALLBACK(display_config_properties_changed_handler), touchpad_settings) < 1) {
+        cerr << "setup_cinnamon(...): g_signal_connect(...) failed." << endl;
+        return EXIT_FAILURE;
+    }
+    
+    // sync on start
+    // also ensures that "send-events" setting is accessed at least once, which is required for the GSettings singal handling to be correctly initialize
+    send_events_handler(touchpad_settings, "send-events", NULL);
+    
+    return EXIT_SUCCESS;
+}
+
+void clean_cinnamon() {
+    g_clear_object(&session_manager_properties);
+    g_clear_object(&display_config_properties);
+    g_clear_object(&touchpad_settings);
+}

--- a/setup-cinnamon.h
+++ b/setup-cinnamon.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2020 TUXEDO Computers GmbH <tux@tuxedocomputers.com>
+//
+// This file is part of TUXEDO Touchpad Switch.
+//
+// This file is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// TUXEDO Touchpad Switch is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with TUXEDO Touchpad Switch.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+int setup_cinnamon(int lockfile);
+void clean_cinnamon();

--- a/tuxedo-touchpad-switch.cpp
+++ b/tuxedo-touchpad-switch.cpp
@@ -28,6 +28,7 @@
 
 #include "touchpad-control.h"
 #include "setup-gnome.h"
+#include "setup-cinnamon.h"
 #include "setup-kde.h"
 
 using std::cout;
@@ -40,6 +41,7 @@ static void gracefull_exit(int signum = 0) {
     int result = EXIT_SUCCESS;
     
     clean_gnome();
+    clean_cinnamon();
     clean_kde();
     
     if (signum < 0) {
@@ -104,6 +106,13 @@ int main() {
         int ret = setup_gnome(lockfile);
         if (ret != EXIT_SUCCESS) {
             cerr << "main(...): setup_gnome(...) failed." << endl;
+            gracefull_exit(-ret);
+        }
+    }
+    else if (strstr(xdg_current_desktop, "X-Cinnamon")) {
+        int ret = setup_cinnamon(lockfile);
+        if (ret != EXIT_SUCCESS) {
+            cerr << "main(...): setup_cinnamon(...) failed." << endl;
             gracefull_exit(-ret);
         }
     }


### PR DESCRIPTION
Small PR that adds support for the Cinnamon DE. I'm using this on a PCSpecialist Recoil 17 (same chassis as Tuxedo Stellaris 17 gen 4).

I'm actually using quite a few other things (like `tuxedo-drivers`) which I edited to support the different model name (thank you for making them open source!!!).

If there's any interest, I could push those changes too (asking only because I've seen some XMG models in there as well).